### PR TITLE
more details and information for containers + toggle buttons; attempts to solve issues #6, #12, #13, #19-23

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,6 +95,7 @@ class ListDatasets extends Component {
 
 export default class App extends Component {
   render() {
+      
     return (
       <div>
         

--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -4,6 +4,7 @@ import VariantSet from './VariantSet.js'
 import ReadGroupSet from './ReadGroupSet.js'
 import FeatureSet from './FeatureSet.js'
 import ID from './ID.js'
+import Toggle from './Toggle.js'
 
 export default class Dataset extends Component {
   render() {
@@ -12,6 +13,7 @@ export default class Dataset extends Component {
       <div>
         <h1>Dataset: {this.props.name} (<ID id={this.props.id} />)</h1>
         <h3>{this.props.description}</h3>
+        <Toggle />
         <div><ListVariantSets {... this.props} datasetId={this.props.id} /></div>
         <div><ListFeatureSets {... this.props} datasetId={this.props.id} /></div>
         <div><h2>Read Group Sets</h2><ListReadGroupSets {... this.props} datasetId={this.props.id} /></div>
@@ -126,7 +128,7 @@ class ListReadGroupSets extends Component {
         success: (result) => {
           this.setState({readgroupsets: this.state.readgroupsets.concat(result.readGroupSets)});
           if (result.nextPageToken !== "") {
-            this.loadFromServer(result.nextPageToken);
+            //this.loadFromServer(result.nextPageToken);
           }
         },
         error: (xhr, status, err) => {

--- a/src/Dataset.js
+++ b/src/Dataset.js
@@ -16,8 +16,9 @@ export default class Dataset extends Component {
         <Toggle />
         <div><ListVariantSets {... this.props} datasetId={this.props.id} /></div>
         <div><ListFeatureSets {... this.props} datasetId={this.props.id} /></div>
-        <div><h2>Read Group Sets</h2><ListReadGroupSets {... this.props} datasetId={this.props.id} /></div>
-      </div>
+        <div><h2>Read Group Sets</h2>
+        <Toggle />
+        <ListReadGroupSets {... this.props} datasetId={this.props.id} /></div></div>
     )
   }
 }
@@ -114,7 +115,7 @@ class ListReadGroupSets extends Component {
   constructor() {
     super()
     this.state = {
-      readgroupsets: []
+      readgroupsets: [] 
     }
   }
   loadFromServer(pageToken=null) {

--- a/src/FeatureSet.js
+++ b/src/FeatureSet.js
@@ -18,7 +18,7 @@ export default class FeatureSet extends Component {
                 <h2>Feature set</h2>
                 <div>id: <ID id={this.props.id} /></div>
                 <div>name: {this.props.name}</div>
-                <div>referenceSetId: {this.props.referenceSetId}</div>
+                <div>referenceSetId: <ID id={this.props.referenceSetId} /></div>
                 </div>
         )
     }

--- a/src/FeatureSet.js
+++ b/src/FeatureSet.js
@@ -14,12 +14,13 @@ import ID from './ID.js'
 export default class FeatureSet extends Component {
     render() {
         return (
-                <div>
-                <h2>Feature set</h2>
-                <div>id: <ID id={this.props.id} /></div>
-                <div>name: {this.props.name}</div>
-                <div>referenceSetId: <ID id={this.props.referenceSetId} /></div>
-                </div>
+            <div>
+            <h2>Feature set</h2>
+            <div>{this.props.description} <span className="label label-primary">description</span></div>
+            <div><ID id={this.props.id} /> <span className="label label-primary">id</span></div>
+            <div>{this.props.name} <span className="label label-primary">name</span></div>
+            <div><ID id={this.props.referenceSetId} /> <span className="label label-primary">refId</span></div>
+            </div>
         )
     }
 }

--- a/src/ID.js
+++ b/src/ID.js
@@ -12,8 +12,6 @@ export default class ID extends Component {
       document.execCommand("copy");
       document.body.removeChild(aux);
       
-      console.log(e._reactInternalInstance._rootNodeID);
-      
       var element = document.getElementById(e._reactInternalInstance._rootNodeID);
       
       element.style.color = "gold";
@@ -26,7 +24,7 @@ export default class ID extends Component {
   render() {
       //console.log({this.props.id}, ": ", {this._reactInternalInstance});
     return (
-      <span id={this._reactInternalInstance._rootNodeID} onClick={()=>this.copyToClipboard(this, this.props.id)}>
+      <span className="pointer" id={this._reactInternalInstance._rootNodeID} onClick={()=>this.copyToClipboard(this, this.props.id)}>
             {this.props.id}
       </span>
     )

--- a/src/ID.js
+++ b/src/ID.js
@@ -3,7 +3,7 @@ import $ from 'jquery'
 
 export default class ID extends Component {
 
-  copyToClipboard(elementId){
+  copyToClipboard(e, elementId){
     
       var aux = document.createElement("input");
       aux.setAttribute("value", elementId);
@@ -11,11 +11,22 @@ export default class ID extends Component {
       aux.select();
       document.execCommand("copy");
       document.body.removeChild(aux);
+      
+      console.log(e._reactInternalInstance._rootNodeID);
+      
+      var element = document.getElementById(e._reactInternalInstance._rootNodeID);
+      
+      element.style.color = "gold";
+      setTimeout(function(){
+        element.style.color = "black";
+      }, 200);
+      
     }
     
   render() {
+      //console.log({this.props.id}, ": ", {this._reactInternalInstance});
     return (
-      <span onClick={()=>this.copyToClipboard(this.props.id)}>
+      <span id={this._reactInternalInstance._rootNodeID} onClick={()=>this.copyToClipboard(this, this.props.id)}>
             {this.props.id}
       </span>
     )

--- a/src/ReadGroupSet.js
+++ b/src/ReadGroupSet.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ID from './ID.js'
+import Toggle from './Toggle.js'
 
 export default class ReadGroupSet extends Component {
   render() {
@@ -47,7 +48,7 @@ class ListReadGroups extends Component {
 
 class ReadGroup extends Component {
   render() {
-    //console.log("read group", this.props)
+    //console.log("read group", this.props);
     return (
       <tr>
         <td>{this.props.name}</td>
@@ -58,6 +59,7 @@ class ReadGroup extends Component {
         <td>{this.props.sampleId}</td>
         <td>{this.props.updated}</td>
         <td><ReadGroupStats {... this.props.stats} /></td>
+            
       </tr>
     )
   }

--- a/src/ReadGroupSet.js
+++ b/src/ReadGroupSet.js
@@ -10,7 +10,7 @@ export default class ReadGroupSet extends Component {
             <div>
         <table>
             <tr>
-                <td id="groupSetHeader" colSpan="6">
+                <td id="groupSetHeader" colSpan="8">
                 Read group set: {this.props.name} (<ID id={this.props.id} />)
                 </td>
             </tr>
@@ -47,19 +47,25 @@ class ListReadGroups extends Component {
 }
 
 class ReadGroup extends Component {
+  humanReadable(d){
+      var date = new Date(parseInt(d));
+      date = date.getMonth() + "/" + date.getDate() + "/" + (parseInt(date.getYear()) + 1900) + " " + (parseInt(date.getHours()) % 12) + ":" + ('0'  + date.getMinutes()).slice(-2) + " " + ((date.getHours() >= 12) ? "PM" : "AM");
+      return date;
+  }
   render() {
+    var updated = this.humanReadable(this.props.updated);
+    var created = this.humanReadable(this.props.created);
     //console.log("read group", this.props);
     return (
       <tr>
         <td>{this.props.name}</td>
         <td><ID id={this.props.id} /></td>
-        <td>{this.props.created}</td>
+        <td>{created}</td>
         <td>{this.props.description}</td>
         <td>{this.props.predictedInsertSize}</td>
         <td>{this.props.sampleId}</td>
-        <td>{this.props.updated}</td>
+        <td>{updated}</td>
         <td><ReadGroupStats {... this.props.stats} /></td>
-            
       </tr>
     )
   }
@@ -73,7 +79,6 @@ class ReadGroupStats extends Component {
             <tr><td><small>un-aligned</small></td><td>{this.props.unalignedReadCount}</td></tr>
             <tr><td><small>base count</small></td><td>{this.props.baseCount}</td></tr>
         </table>
-        
     )
   }
 }

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react'
+import ID from './ID.js'
+
+export default class Reference extends Component {
+  render() {
+    return (
+      <tr>
+        <td><ID id={this.props.id} /></td>
+        <td className="right">{this.props.name}</td>
+        <td className="right">{this.props.sourceUri}</td>
+        <td className="right">{this.props.sourceDivergence}</td>
+        <td className="right">{this.props.length}</td>
+        <td className="right">{this.props.ncbiTaxonId}</td>
+        <td className="right">{this.props.isDerived}</td>
+        <td className="right">{this.props.md5checksum}</td>
+      </tr>
+    )
+  }
+}

--- a/src/ReferenceSet.js
+++ b/src/ReferenceSet.js
@@ -1,15 +1,22 @@
 import React, { Component } from 'react';
-import ID from './ID.js'
 import $ from 'jquery'
+import ID from './ID.js'
+import Toggle from './Toggle.js'
+import Reference from './Reference.js'
 
 export default class ReferenceSet extends Component {
   render() {
     // <ListVariants variantSetId={this.props.id} baseurl={this.props.baseurl} />
+      console.log(this.props);
     return (
       <div>
         <h1>Reference set: {this.props.name} (<ID id={this.props.id} />)</h1>
         <h3>{this.props.description}</h3>
-        <div>md5checksum: {this.props.md5checksum}</div>
+        <div>{this.props.md5checksum} <span className="label label-primary">md5checksum</span></div>
+        <div>{this.props.ncbiTaxonId} <span className="label label-primary">ncbiTaxonId</span></div>
+        <div>{this.props.sourceUri} <span className="label label-primary">sourceUri</span></div>
+        <Toggle />
+        <ListReferences baseurl={this.props.baseurl} referenceSetId={this.props.id} />
       </div>
     )
   }
@@ -34,7 +41,7 @@ class ListReferences extends Component {
         success: (result) => {
           this.setState({references: this.state.references.concat(result.references)});
           if (result.nextPageToken !== "") {
-            this.loadFromServer(result.nextPageToken)
+            //this.loadFromServer(result.nextPageToken)
           }
         },
         error: (xhr, status, err) => {
@@ -52,22 +59,22 @@ class ListReferences extends Component {
     let references = this.state.references;
     return (
       <div>
-      <h2>Variants</h2>
+      <h3>References</h3>
+      <table>
+      <tr>
+        <th>id</th>
+        <th className="right">name</th>
+        <th className="right">source Uri</th>
+        <th className="right">source divergence</th>
+        <th className="right">length</th>
+        <th className="right">ncbi taxon ID</th>
+        <th className="right">is derived</th>
+        <th>md5checksum</th>
+      </tr>
       {references.map((reference) => {
         return <Reference baseurl={this.props.baseurl} {... reference} />
       })}
-      </div>
-    )
-  }
-}
-
-class Reference extends Component {
-  render() {
-    return (
-      <div>
-        <h3>Variant</h3>
-        <div>name: {this.props.name}</div>
-        <div>id: {this.props.id}</div>
+      </table>
       </div>
     )
   }

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -16,7 +16,6 @@ export default class Toggle extends Component {
         return content.is(":visible") ? "hide" : "show";
       });
     });
-    
   }
     
   render() {
@@ -26,5 +25,6 @@ export default class Toggle extends Component {
         hide
       </button>
     )
+
   }
 }

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import $ from 'jquery'
+
+export default class Toggle extends Component {
+
+  toggleView(e){
+    var header = $(document.getElementById(e._reactInternalInstance._rootNodeID));
+    
+    //getting all sibling elements
+    var content = header.nextAll();
+    
+    //hide if visible, show if not
+    content.toggle(0, function () {
+       header.text(function () {
+        //change text based on condition
+        return content.is(":visible") ? "hide" : "show";
+      });
+    });
+    
+  }
+    
+  render() {
+      //console.log({this.props.id}, ": ", {this._reactInternalInstance});
+    return (
+      <button style={{width: "100%"}} id={this._reactInternalInstance._rootNodeID} onClick={()=>this.toggleView(this)}>
+        hide
+      </button>
+    )
+  }
+}

--- a/src/VariantAnnotationSet.js
+++ b/src/VariantAnnotationSet.js
@@ -5,13 +5,13 @@ import ID from './ID.js'
 
 export default class VariantAnnotationSet extends Component {
   render() {
+      console.log("vas", this.props);
     // <ListVariants variantSetId={this.props.id} baseurl={this.props.baseurl} />
     return (
       <div>
         <h3>Variant Annotation Set</h3>
-        <div>name: {this.props.name}</div>
-        <div><ID id={this.props.id} /></div>
-        <div>refId: {this.props.referenceSetId}</div>
+        <div>{this.props.name} <span className="label label-primary">name</span></div>
+        <div><ID id={this.props.id} /> <span className="label label-primary">id</span></div>
       </div>
     )
   }

--- a/src/VariantAnnotationSet.js
+++ b/src/VariantAnnotationSet.js
@@ -1,14 +1,16 @@
 import React, { Component } from 'react';
 import Variant from './Variant.js'
+import Toggle from './Toggle.js'
+import ID from './ID.js'
 
 export default class VariantAnnotationSet extends Component {
   render() {
     // <ListVariants variantSetId={this.props.id} baseurl={this.props.baseurl} />
     return (
       <div>
-        <h3>Variant annotation set</h3>
+        <h3>Variant Annotation Set</h3>
         <div>name: {this.props.name}</div>
-        <div>id: {this.props.id}</div>
+        <div><ID id={this.props.id} /></div>
         <div>refId: {this.props.referenceSetId}</div>
       </div>
     )

--- a/src/VariantSet.js
+++ b/src/VariantSet.js
@@ -13,9 +13,9 @@ export default class VariantSet extends Component {
     return (
       <div>
         <h2>Variant set</h2>
-        <div>name: {this.props.name}</div>
-        <div>id: <ID id={this.props.id} /></div>
-        <div>refId: <ID id={this.props.referenceSetId} /></div>
+        <div>{this.props.name} <span className="label label-primary">name</span> </div>
+        <div><ID id={this.props.id} /> <span className="label label-primary">id</span></div>
+        <div><ID id={this.props.referenceSetId} /> <span className="label label-primary">refId</span></div>
         <Toggle />
         <ListMetadata metadata={this.props.metadata}/>
         <ListVariantAnnotationSets variantSetId={this.props.id} baseurl={this.props.baseurl} />

--- a/src/VariantSet.js
+++ b/src/VariantSet.js
@@ -4,6 +4,7 @@ import Variant from './Variant.js'
 import VariantAnnotationSet from './VariantAnnotationSet.js'
 import ID from './ID.js'
 import CallSet from './CallSet.js'
+import Toggle from './Toggle.js'
 
 export default class VariantSet extends Component {
   render() {
@@ -15,6 +16,7 @@ export default class VariantSet extends Component {
         <div>name: {this.props.name}</div>
         <div>id: <ID id={this.props.id} /></div>
         <div>refId: {this.props.referenceSetId}</div>
+        <Toggle />
         <ListMetadata metadata={this.props.metadata}/>
         <ListVariantAnnotationSets variantSetId={this.props.id} baseurl={this.props.baseurl} />
       </div>

--- a/src/VariantSet.js
+++ b/src/VariantSet.js
@@ -15,7 +15,7 @@ export default class VariantSet extends Component {
         <h2>Variant set</h2>
         <div>name: {this.props.name}</div>
         <div>id: <ID id={this.props.id} /></div>
-        <div>refId: {this.props.referenceSetId}</div>
+        <div>refId: <ID id={this.props.referenceSetId} /></div>
         <Toggle />
         <ListMetadata metadata={this.props.metadata}/>
         <ListVariantAnnotationSets variantSetId={this.props.id} baseurl={this.props.baseurl} />
@@ -140,8 +140,7 @@ class ListMetadata extends Component {
                 <th>type</th>
             </tr>
             {this.props.metadata.map((meta) => {
-             
-             return <Metadata baseurl={this.props.baseurl} {... meta} />
+             return <Metadata baseurl={this.props.baseurl} {... meta} keyValue={meta.key}/>
                 
         })}</table>
         </div>
@@ -155,7 +154,7 @@ class Metadata extends Component {
                 <td>{this.props.description}</td>
                 <td><ID id={this.props.id} /></td>
                 <td>{this.props.number}</td>
-                <td>{this.props.key}</td>
+                <td>{this.props.keyValue}</td>
                 <td>{this.props.value}</td>
                 <td>{this.props.type}</td>
                 </tr>

--- a/styles.css
+++ b/styles.css
@@ -38,3 +38,16 @@ th {
 #statsTable{
     table-layout: auto;
 }
+
+button {
+    background-color: black;
+    display: inline-block;
+    border: none;
+    color: white;
+    text-align: center;
+    text-decoration: none;
+    font-size: 16px;
+    margin: 4px 2px;
+    width: 100%;
+    cursor: pointer;
+}


### PR DESCRIPTION
6) large containers have a toggle button with show/hide text
12) ID's show hand cursor on hover and flash banana slug yellow when clicked on
13) keys are shown in metadata after the word "key" was changed to "keyValue", maybe "key" can't be passed as a prop
19) created and updated in read groups show date and time
22) all containers have bootstrap labels

for now, only the first page of read groups render because it was difficult to test certain things while pages are constantly loading
